### PR TITLE
Remove unused APIKeyConfig type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -44,11 +44,6 @@ export enum ProblemType {
   ERROR_GENERATING = 'ERROR_GENERATING', // Type for when AI fails
 }
 
-export interface APIKeyConfig {
-  apiKey: string;
-  isValid: boolean;
-}
-
 export interface QuestionBatch {
   questions: MathProblem[];
   level: DifficultyLevel;


### PR DESCRIPTION
## Summary
- remove the APIKeyConfig interface from `types.ts`
- verify no references exist across the project

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run type-check` *(fails: missing declaration for react-katex)*