### PR TITLE
Fix level up modal overflow on mobile

### DIFF
--- a/components/LevelUpModal.tsx
+++ b/components/LevelUpModal.tsx
@@ -96,7 +96,7 @@ const LevelUpModal: React.FC<LevelUpModalProps> = ({ level, onClose }) => {
       )}
 
       {/* Main Modal */}
-      <div className="glass-card-strong rounded-2xl compact-spacing-lg max-w-xl w-full mx-auto text-center animate-bounce-in">
+      <div className="glass-card-strong rounded-2xl compact-spacing-lg max-w-xl w-full mx-auto text-center animate-bounce-in max-h-[90vh] overflow-y-auto">
         {/* Header with Trophy */}
         <div className="mb-6">
           <div className="flex justify-center mb-4">


### PR DESCRIPTION
## Summary
- ensure the level up modal doesn't exceed the viewport height

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: TS6133 and TS7030 errors)*