### PR TITLE
Add basic Node test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+dist-tests
+dist-tests-test
 *.local
 .env
 

--- a/build-tests.sh
+++ b/build-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Compile TypeScript files needed for tests to dist-tests using tsc
+# We only compile selected files to keep it lightweight.
+rm -rf dist-tests
+npx tsc services/scoring.ts types.ts constants.ts \
+  --module ES2020 \
+  --moduleResolution node \
+  --target ES2020 \
+  --outDir dist-tests

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,4 @@
-import { DifficultyLevel } from './types';
+import { DifficultyLevel } from './types.js';
 
 export const STARTING_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_1;
 export const MAX_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_20;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "build:test": "sh ./build-tests.sh",
+    "test": "npm run build:test && node --test tests/*.test.js"
   },
   "dependencies": {
     "@google/genai": "latest",

--- a/services/scoring.ts
+++ b/services/scoring.ts
@@ -1,0 +1,14 @@
+import { DifficultyLevel } from '../types.js';
+
+/**
+ * Calculate the points awarded for a correct answer at a given difficulty level.
+ * Each level awards 10 points multiplied by the numeric level.
+ * @param level The difficulty level of the question.
+ * @returns Number of points awarded.
+ */
+export const pointsForLevel = (level: DifficultyLevel): number => {
+  if (level < DifficultyLevel.LEVEL_1 || level > DifficultyLevel.LEVEL_20) {
+    throw new Error('Invalid difficulty level');
+  }
+  return level * 10;
+};

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pointsForLevel } from '../dist-tests/services/scoring.js';
+import { DifficultyLevel } from '../dist-tests/types.js';
+
+test('pointsForLevel awards 10 points per level', () => {
+  assert.strictEqual(pointsForLevel(DifficultyLevel.LEVEL_1), 10);
+  assert.strictEqual(pointsForLevel(DifficultyLevel.LEVEL_5), 50);
+});
+
+test('pointsForLevel throws for invalid level', () => {
+  assert.throws(() => pointsForLevel(0), /Invalid difficulty level/);
+});


### PR DESCRIPTION
## Summary
- add new scoring service for calculating points
- update imports to use `.js` extension
- create Node test with `node:test`
- setup build script and npm test command
- ignore generated test output

## Testing
- `npm test`