### PR TITLE
Support custom level at game start

### DIFF
--- a/build-tests.sh
+++ b/build-tests.sh
@@ -2,7 +2,7 @@
 # Compile TypeScript files needed for tests to dist-tests using tsc
 # We only compile selected files to keep it lightweight.
 rm -rf dist-tests
-npx tsc services/scoring.ts types.ts constants.ts \
+npx tsc services/scoring.ts services/mathProblemService.ts types.ts constants.ts \
   --module ES2020 \
   --moduleResolution node \
   --target ES2020 \

--- a/services/mathProblemService.ts
+++ b/services/mathProblemService.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
-import { MathProblem, DifficultyLevel, ProblemType, QuestionBatch } from '../types';
-import { TOTAL_QUESTIONS } from '../constants';
+import { MathProblem, DifficultyLevel, ProblemType, QuestionBatch } from '../types.js';
+import { TOTAL_QUESTIONS } from '../constants.js';
 
 // Storage key for persisting the API key in the browser
 const API_KEY_STORAGE_KEY = 'mathGeniusApiKey';

--- a/tests/startLevel.test.js
+++ b/tests/startLevel.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateProblem } from '../dist-tests/services/mathProblemService.js';
+import { DifficultyLevel, ProblemType } from '../dist-tests/types.js';
+
+// When no API key is configured, generateProblem should still
+// return a placeholder problem with the requested difficulty.
+
+test('first generated problem matches requested level', async () => {
+  const level = DifficultyLevel.LEVEL_3;
+  const problem = await generateProblem(level);
+  assert.equal(problem.difficulty, level);
+  assert.equal(problem.problemType, ProblemType.ERROR_GENERATING);
+});


### PR DESCRIPTION
## Summary
- allow `prefetchProblem` and `loadNextProblem` to work with a passed-in level
- use provided level when starting the game
- compile `mathProblemService.ts` for node tests
- test that generated problem keeps requested difficulty

## Testing
- `npm test`