### PR TITLE
Replace SVG icons with emoji

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,226 +1,77 @@
 import React from 'react';
 
-interface IconProps extends React.SVGProps<SVGSVGElement> {
+interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
   className?: string;
 }
 
-export const TimerIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-    />
-  </svg>
+export const TimerIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="timer" className={`inline-block ${className}`} {...props}>
+    ⏱️
+  </span>
 );
 
-export const CheckCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-    />
-  </svg>
+export const CheckCircleIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="correct" className={`inline-block ${className}`} {...props}>
+    ✅
+  </span>
 );
 
-export const XCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-    />
-  </svg>
+export const XCircleIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="incorrect" className={`inline-block ${className}`} {...props}>
+    ❌
+  </span>
 );
 
-export const SparklesIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L1.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L24 5.25l-.813 2.846a4.5 4.5 0 0 0-3.09 3.09L18.25 12ZM18.25 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09L12 18.75l.813-2.846a4.5 4.5 0 0 0 3.09-3.09L18.25 12Z"
-    />
-  </svg>
+export const SparklesIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="sparkles" className={`inline-block ${className}`} {...props}>
+    ✨
+  </span>
 );
 
-export const StarIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.82.61l-4.725-2.885a.562.562 0 0 0-.652 0l-4.725 2.885a.562.562 0 0 1-.82-.61l1.285-5.385a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
-    />
-  </svg>
+export const StarIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="star" className={`inline-block ${className}`} {...props}>
+    ⭐
+  </span>
 );
 
-export const TrendingUpIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"
-    />
-  </svg>
+export const TrendingUpIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="trending up" className={`inline-block ${className}`} {...props}>
+    📈
+  </span>
 );
 
-export const ArrowUpIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 19.5v-15m0 0-.6.6m.6-.6.6.6m-9 6H21"
-    />
-  </svg>
+export const ArrowUpIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="arrow up" className={`inline-block ${className}`} {...props}>
+    ⬆️
+  </span>
 );
 
-export const TrophyIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-4.5A3.375 3.375 0 0 0 12.75 9H11.25A3.375 3.375 0 0 0 7.5 12.375V18.75m9 0H21M7.5 18.75H3M12 14.25V21m0-13.5V4.5A2.25 2.25 0 0 1 14.25 2.25h1.5A2.25 2.25 0 0 1 18 4.5v3.75m-12 0V4.5A2.25 2.25 0 0 0 8.25 2.25H9.75A2.25 2.25 0 0 0 12 4.5v3.75"
-    />
-  </svg>
+export const TrophyIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="trophy" className={`inline-block ${className}`} {...props}>
+    🏆
+  </span>
 );
 
-export const RefreshIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-    />
-  </svg>
+export const RefreshIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="refresh" className={`inline-block ${className}`} {...props}>
+    🔄
+  </span>
 );
 
-export const GeniusIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.393-.029.808-.029 1.201 0 1.131.094 1.976 1.057 1.976 2.192V7.5M8.25 7.5h7.5M8.25 7.5V9M8.25 9H5.25M8.25 9v1.5m0-1.5V7.5m7.5 1.5h2.625m-2.625-1.5V7.5m0 1.5V9M15 9h.008v.008H15V9Zm-.375 0H12.12C12.052 9 12 8.948 12 8.875V6.125c0-.073.052-.125.125-.125h2.75c.073 0 .125.052.125.125V8.875c0 .073-.052.125-.125.125ZM12 15v2.25A2.25 2.25 0 0 0 14.25 19.5h1.5A2.25 2.25 0 0 0 18 17.25V15M12 15H9.75A2.25 2.25 0 0 1 7.5 12.75V15m3-7.5V7.5m0-6v6m0 0 .001 6m1.5-6H15m-3 0H9"
-    />
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9.75 16.125c.393.412.763.796 1.125 1.125m2.25-2.25c.362-.328.732-.712 1.125-1.125M12 15.75l1.125-1.125M12 15.75l-1.125-1.125m0 0L9.75 13.5m1.125 1.125L12 13.5m0 0l1.125 1.125M12 13.5l-1.125 1.125"
-    />
-  </svg>
+export const GeniusIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="genius" className={`inline-block ${className}`} {...props}>
+    🧠
+  </span>
 );
 
-export const AlertTriangleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.008v.008H12v-.008Z"
-    />
-  </svg>
+export const AlertTriangleIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="alert" className={`inline-block ${className}`} {...props}>
+    ⚠️
+  </span>
 );
 
-export const PlayIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={2}
-    stroke="currentColor"
-    className={className}
-    {...props}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M5.25 5.654c0-.856.917-1.398 1.667-.986l11.54 6.346a1.125 1.125 0 0 1 0 1.972l-11.54 6.346a1.125 1.125 0 0 1-1.667-.986V5.654Z"
-    />
-  </svg>
+export const PlayIcon: React.FC<IconProps> = ({ className = '', ...props }) => (
+  <span role="img" aria-label="play" className={`inline-block ${className}`} {...props}>
+    ▶️
+  </span>
 );

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -16,35 +16,13 @@ const ThemeToggle: React.FC<ThemeToggleProps> = ({ className = '' }) => {
       title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
     >
       {theme === 'light' ? (
-        <svg
-          className="w-5 h-5 text-yellow-400"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-          />
-        </svg>
+        <span role="img" aria-label="sun" className="inline-block w-5 h-5 text-yellow-400">
+          🌞
+        </span>
       ) : (
-        <svg
-          className="w-5 h-5 text-blue-300"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
-          />
-        </svg>
+        <span role="img" aria-label="moon" className="inline-block w-5 h-5 text-blue-300">
+          🌜
+        </span>
       )}
     </button>
   );


### PR DESCRIPTION
## Summary
- simplify icon components to use emoji instead of SVGs
- switch theme toggle icons to emoji

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*
- `npm test` *(fails: cannot find @google/genai during build)*