### PR TITLE
Adjust timer scaling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { GameState, MathProblem, DifficultyLevel, ProblemType } from './types';
 import { generateProblem, hasValidApiKey, loadApiKeyFromStorage } from './services/mathProblemService';
-import { STARTING_LEVEL, MAX_LEVEL, STRIKES_TO_LEVEL_UP, INITIAL_TIME_PER_QUESTION, TIME_INCREMENT_PER_LEVEL, TOTAL_QUESTIONS, CORRECT_MESSAGES, INCORRECT_MESSAGES, LEVEL_UP_MESSAGES } from './constants';
+import { STARTING_LEVEL, MAX_LEVEL, STRIKES_TO_LEVEL_UP, INITIAL_TIME_PER_QUESTION, TIME_AT_LEVEL_ONE, TIME_AT_MAX_LEVEL, TOTAL_QUESTIONS, CORRECT_MESSAGES, INCORRECT_MESSAGES, LEVEL_UP_MESSAGES } from './constants';
 import StartScreen from './components/StartScreen';
 import GameScreen from './components/GameScreen';
 import GameOverScreen from './components/GameOverScreen';
@@ -57,7 +57,10 @@ const App = (): React.JSX.Element => {
   }, []);
 
   const computeTimerDuration = (level: DifficultyLevel): number => {
-    return INITIAL_TIME_PER_QUESTION + (level - 1) * TIME_INCREMENT_PER_LEVEL;
+    const scale = Math.log(level) / Math.log(MAX_LEVEL);
+    const rawDuration =
+      TIME_AT_LEVEL_ONE + (TIME_AT_MAX_LEVEL - TIME_AT_LEVEL_ONE) * scale;
+    return Math.round(rawDuration);
   };
 
 

--- a/components/GameScreen.tsx
+++ b/components/GameScreen.tsx
@@ -311,7 +311,7 @@ const GameScreen: React.FC<GameScreenProps> = memo(({
           {/* Timer */}
           <div className={`flex items-center justify-center space-x-2 text-xl sm:text-2xl font-bold glass-card p-2 sm:p-3 rounded-xl mb-4 sm:mb-6 ${problem?.problemType === ProblemType.ERROR_GENERATING ? 'opacity-50' : ''}`}>
             <TimerIcon className={`w-6 h-6 sm:w-8 sm:h-8 ${problem?.problemType === ProblemType.ERROR_GENERATING ? 'text-gray-500' : 'text-red-400'} ${timeLeft <= 5 && timeLeft > 0 ? 'animate-pulse' : ''}`} />
-            <span className={getTimerClass()}>{timeLeft}s</span>
+            <span className={getTimerClass()}>{Math.ceil(timeLeft)}s</span>
             {timeLeft <= 5 && timeLeft > 0 && problem?.problemType !== ProblemType.ERROR_GENERATING && (
               <div className="text-xs sm:text-sm text-red-400 font-medium animate-bounce">HURRY!</div>
             )}

--- a/constants.ts
+++ b/constants.ts
@@ -3,8 +3,9 @@ import { DifficultyLevel } from './types.js';
 export const STARTING_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_1;
 export const MAX_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_20;
 export const STRIKES_TO_LEVEL_UP: number = 3;
-export const INITIAL_TIME_PER_QUESTION: number = 30; // seconds (Increased from 20)
-export const TIME_INCREMENT_PER_LEVEL: number = 3; // seconds (Was TIME_DECREMENT_PER_LEVEL, now time increases)
+export const TIME_AT_LEVEL_ONE: number = 15; // seconds
+export const TIME_AT_MAX_LEVEL: number = 600; // seconds
+export const INITIAL_TIME_PER_QUESTION: number = TIME_AT_LEVEL_ONE;
 export const TOTAL_QUESTIONS: number = 10;
 
 export const CORRECT_MESSAGES: string[] = [


### PR DESCRIPTION
## Summary
- introduce `TIME_AT_LEVEL_ONE` and `TIME_AT_MAX_LEVEL` constants
- compute timer duration using new range
- use logarithmic scaling for per-level timer
- round timer display to show whole seconds

## Testing
- `npm test` *(fails: Cannot find module '@google/genai')*