### PR TITLE
Adjust timer scaling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { GameState, MathProblem, DifficultyLevel, ProblemType } from './types';
 import { generateProblem, hasValidApiKey, loadApiKeyFromStorage } from './services/mathProblemService';
-import { STARTING_LEVEL, MAX_LEVEL, STRIKES_TO_LEVEL_UP, INITIAL_TIME_PER_QUESTION, TIME_INCREMENT_PER_LEVEL, TOTAL_QUESTIONS, CORRECT_MESSAGES, INCORRECT_MESSAGES, LEVEL_UP_MESSAGES } from './constants';
+import { STARTING_LEVEL, MAX_LEVEL, STRIKES_TO_LEVEL_UP, INITIAL_TIME_PER_QUESTION, TIME_AT_LEVEL_ONE, TIME_AT_MAX_LEVEL, REVERSE_LOG_BASE, TOTAL_QUESTIONS, CORRECT_MESSAGES, INCORRECT_MESSAGES, LEVEL_UP_MESSAGES } from './constants';
 import StartScreen from './components/StartScreen';
 import GameScreen from './components/GameScreen';
 import GameOverScreen from './components/GameOverScreen';
@@ -57,7 +57,12 @@ const App = (): React.JSX.Element => {
   }, []);
 
   const computeTimerDuration = (level: DifficultyLevel): number => {
-    return INITIAL_TIME_PER_QUESTION + (level - 1) * TIME_INCREMENT_PER_LEVEL;
+    const normalizedLevel = (level - 1) / (MAX_LEVEL - 1);
+    const reversedLog =
+      1 - Math.log(1 + (REVERSE_LOG_BASE - 1) * (1 - normalizedLevel)) / Math.log(REVERSE_LOG_BASE);
+    const duration =
+      TIME_AT_LEVEL_ONE + (TIME_AT_MAX_LEVEL - TIME_AT_LEVEL_ONE) * reversedLog;
+    return Math.round(duration);
   };
 
 

--- a/constants.ts
+++ b/constants.ts
@@ -3,8 +3,10 @@ import { DifficultyLevel } from './types.js';
 export const STARTING_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_1;
 export const MAX_LEVEL: DifficultyLevel = DifficultyLevel.LEVEL_20;
 export const STRIKES_TO_LEVEL_UP: number = 3;
-export const INITIAL_TIME_PER_QUESTION: number = 30; // seconds (Increased from 20)
-export const TIME_INCREMENT_PER_LEVEL: number = 3; // seconds (Was TIME_DECREMENT_PER_LEVEL, now time increases)
+export const TIME_AT_LEVEL_ONE: number = 15; // seconds
+export const TIME_AT_MAX_LEVEL: number = 600; // seconds
+export const REVERSE_LOG_BASE: number = 10;
+export const INITIAL_TIME_PER_QUESTION: number = TIME_AT_LEVEL_ONE;
 export const TOTAL_QUESTIONS: number = 10;
 
 export const CORRECT_MESSAGES: string[] = [


### PR DESCRIPTION
## Summary
- introduce `REVERSE_LOG_BASE` constant to control timer curve
- compute timer duration using a reverse-logarithmic formula

## Testing
- `npm test`
