### PR TITLE
Implement batch clearing on level up

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { GameState, MathProblem, DifficultyLevel, ProblemType } from './types';
-import { generateProblem, hasValidApiKey, loadApiKeyFromStorage } from './services/mathProblemService';
+import { generateProblem, hasValidApiKey, loadApiKeyFromStorage, clearQuestionCache, clearBatchForLevel } from './services/mathProblemService';
 import { STARTING_LEVEL, MAX_LEVEL, STRIKES_TO_LEVEL_UP, INITIAL_TIME_PER_QUESTION, TIME_PER_LEVEL, TOTAL_QUESTIONS, CORRECT_MESSAGES, INCORRECT_MESSAGES, LEVEL_UP_MESSAGES } from './constants';
 import StartScreen from './components/StartScreen';
 import GameScreen from './components/GameScreen';
@@ -171,7 +171,8 @@ const App = (): React.JSX.Element => {
           setCurrentLevel(prevLevel => {
             const newLevel = Math.min(MAX_LEVEL, prevLevel + 1) as DifficultyLevel;
             if (newLevel !== prevLevel) {
-                setNextProblemBuffer(null); 
+                clearBatchForLevel(newLevel);
+                setNextProblemBuffer(null);
             }
             return newLevel;
           });
@@ -223,6 +224,7 @@ const App = (): React.JSX.Element => {
 
 
   const startGame = async (level: DifficultyLevel = STARTING_LEVEL): Promise<void> => {
+    clearQuestionCache();
     setScore(0);
     setStrikes(0);
     setCurrentLevel(level);
@@ -242,6 +244,7 @@ const App = (): React.JSX.Element => {
   };
 
   const restartGame = (): void => {
+    clearQuestionCache();
     setGameState(GameState.NOT_STARTED);
     setCurrentProblem(null);
     setTimeLeft(INITIAL_TIME_PER_QUESTION); 

--- a/services/mathProblemService.ts
+++ b/services/mathProblemService.ts
@@ -398,3 +398,11 @@ export const clearQuestionCache = (): void => {
   questionBatches.clear();
   saveQuestionBatchesToStorage();
 };
+
+// Remove the cached batch for a specific level
+export const clearBatchForLevel = (level: DifficultyLevel): void => {
+  if (questionBatches.has(level)) {
+    questionBatches.delete(level);
+  }
+  saveQuestionBatchesToStorage();
+};

--- a/tests/cacheClearOnLevelUp.test.js
+++ b/tests/cacheClearOnLevelUp.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class FakeLocalStorage {
+  constructor() { this.store = {}; }
+  getItem(key) { return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null; }
+  setItem(key, value) { this.store[key] = String(value); }
+  removeItem(key) { delete this.store[key]; }
+}
+
+test('cached batch is removed when clearBatchForLevel is called', async () => {
+  globalThis.localStorage = new FakeLocalStorage();
+
+  const level = 2;
+  const fakeBatch = {
+    questions: [
+      { id: 'q1', questionText: '1+1', answer: 2, difficulty: level, problemType: 'AI_GENERATED', hasLatex: false }
+    ],
+    level,
+    timestamp: Date.now()
+  };
+
+  localStorage.setItem('mathGeniusBatches', JSON.stringify({ [level]: fakeBatch }));
+
+  const { clearBatchForLevel } = await import('../dist-tests/services/mathProblemService.js');
+
+  assert.ok(JSON.parse(localStorage.getItem('mathGeniusBatches')).hasOwnProperty(level));
+
+  clearBatchForLevel(level);
+
+  assert.deepEqual(JSON.parse(localStorage.getItem('mathGeniusBatches') ?? '{}'), {});
+});


### PR DESCRIPTION
## Summary
- call new `clearBatchForLevel` when level increases
- clear cached question batches when starting or restarting a game
- add `clearBatchForLevel` to `mathProblemService`
- test that `clearBatchForLevel` removes a stored batch

## Testing
- `npm run build:test`
- `npm test`